### PR TITLE
Ignore disabled options in setting string (Issue #206)

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -138,7 +138,6 @@ def guiMain(settings=None):
     # Hold the results of the user's decisions here
     guivars = {}
     widgets = {}
-    dependencies = {}
     presets = {}
 
     # Hierarchy
@@ -180,21 +179,13 @@ def guiMain(settings=None):
             if widget_type == 'Scale':
                 widget.configure(fg='Black'if enabled else 'Grey')
 
-
-    def check_dependency(name):
-        if name in dependencies:
-            return dependencies[name](guivars)
-        else:
-            return True
-
-
     def show_settings(*event):
         settings = guivars_to_settings(guivars)
         settings_string_var.set( settings.get_settings_string() )
 
         # Update any dependencies
         for info in setting_infos:
-            dep_met = check_dependency(info.name)
+            dep_met = settings.check_dependency(info.name)
 
             if info.name in widgets:
                 toggle_widget(widgets[info.name], dep_met)
@@ -269,9 +260,6 @@ def guiMain(settings=None):
     ############
 
     for info in setting_infos:
-        if info.gui_params and 'dependency' in info.gui_params:
-            dependencies[info.name] = info.gui_params['dependency']
-
         if info.gui_params and 'group' in info.gui_params:
             if info.gui_params['widget'] == 'Checkbutton':
                 # Determine the initial value of the checkbox
@@ -603,9 +591,11 @@ def guiMain(settings=None):
             else:
                 notebook.tab(2, state="disabled")
             notebook.tab(3, state="normal")
-            toggle_widget(widgets['world_count'], check_dependency('world_count'))
-            toggle_widget(widgets['create_spoiler'], check_dependency('create_spoiler'))
-            toggle_widget(widgets['count'], check_dependency('count'))
+
+            settings = guivars_to_settings(guivars)
+            toggle_widget(widgets['world_count'], settings.check_dependency('world_count'))
+            toggle_widget(widgets['create_spoiler'], settings.check_dependency('create_spoiler'))
+            toggle_widget(widgets['count'], settings.check_dependency('count'))
             toggle_widget(widgets['settings_presets'], True)
         else:
             notebook.tab(1, state="disabled")

--- a/Main.py
+++ b/Main.py
@@ -69,7 +69,8 @@ def main(settings, window=dummy_window()):
         else:
             settings.player_num = 1
 
-    settings.update()
+    settings.remove_disabled()
+
     logger.info('OoT Randomizer Version %s  -  Seed: %s\n\n', __version__, settings.seed)
     random.seed(settings.numeric_seed)
     for i in range(0, settings.world_count):

--- a/Settings.py
+++ b/Settings.py
@@ -9,7 +9,7 @@ import json
 
 from version import __version__
 from Utils import random_choices, local_path
-from SettingsList import setting_infos
+from SettingsList import setting_infos, get_setting_info
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
 
@@ -200,6 +200,21 @@ class Settings():
     def update(self):
         self.settings_string = self.get_settings_string()
         self.numeric_seed = self.get_numeric_seed()
+
+    def check_dependency(self, setting_name):
+        info = get_setting_info(setting_name)
+        if info.gui_params is not None and 'dependency' in info.gui_params:
+            return info.gui_params['dependency'](self) == None
+        else:
+            return True
+
+    def remove_disabled(self):
+        for info in setting_infos:
+            if info.gui_params is not None and 'dependency' in info.gui_params:
+                new_value = info.gui_params['dependency'](self)
+                if new_value != None:
+                    self.__dict__[info.name] = new_value
+        self.settings_string = self.get_settings_string()
 
     # add the settings as fields, and calculate information based on them
     def __init__(self, settings_dict):

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -410,7 +410,7 @@ setting_infos = [
             'type': int
         },
         {
-            'dependency': lambda guivar: guivar['compress_rom'].get() not in ['No Output', 'Patch File'],
+            'dependency': lambda settings: 1 if settings.compress_rom in ['None', 'Patch'] else None,
         }),
     Checkbutton(
             name           = 'create_spoiler',
@@ -432,7 +432,7 @@ setting_infos = [
                          ''',
         gui_text='Create Cosmetics Log',
         gui_group='rom_tab',
-        gui_dependency=lambda guivar: guivar['compress_rom'].get() not in ['No Output', 'Patch File'],
+        gui_dependency=lambda settings: False if settings.compress_rom in ['None', 'Patch'] else None,
         default=True,
         shared=False,
     ),
@@ -726,7 +726,7 @@ setting_infos = [
                              enabled, then there will be hints for which
                              trials need to be completed.
                              ''',
-            gui_dependency = lambda guivar: not guivar['trials_random'].get(),
+            gui_dependency = lambda settings: 0 if settings.trials_random else None,
             shared         = True,
             ),
     Checkbutton(
@@ -892,7 +892,7 @@ setting_infos = [
                              The Poe buyer will give a reward for turning
                              in the chosen number of Big Poes.
                              ''',
-            gui_dependency = lambda guivar: not guivar['big_poe_count_random'].get(),
+            gui_dependency = lambda settings: 1 if settings.big_poe_count_random else None,
             shared         = True,
             ),
     Checkbutton(
@@ -1302,7 +1302,7 @@ setting_infos = [
                              12: All dungeons will have
                              Master Quest redesigns.
                              ''',
-            gui_dependency = lambda guivar: not guivar['mq_dungeons_random'].get(),
+            gui_dependency = lambda settings: 0 if settings.mq_dungeons_random else None,
             shared         = True,
             ),
     Setting_Info('disabled_locations', list, math.ceil(math.log(len(location_table) + 2, 2)), True,

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-__version__ = '3.11.27 f.LUM'
+__version__ = '3.12.1 f.LUM'


### PR DESCRIPTION
The setting strings are different, but they will still produce the same seed. This allows options to keep they state when disabling. that being said, people will almost always just copy setting strings in so this is relatively moot. I'm unsure if this behavior is honestly more expected, but I'm adding this is as mainly a UX reaction since people seem to think it should be this way.